### PR TITLE
Support for transparent images & bigger scale factors

### DIFF
--- a/NVIDIA Ansel AI Up Res/MainWindow.xaml
+++ b/NVIDIA Ansel AI Up Res/MainWindow.xaml
@@ -19,20 +19,23 @@
         </Grid.ColumnDefinitions>
 
         <Grid x:Name="browseGrid"
-              Width="100"
-              Height="100"
+              Width="179"
               HorizontalAlignment="Left">
-            <Border BorderThickness="1" BorderBrush="Black" CornerRadius="4"/>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="49*"/>
+                <ColumnDefinition Width="43*"/>
+            </Grid.ColumnDefinitions>
+            <Border BorderThickness="1" BorderBrush="Black" CornerRadius="4" Grid.ColumnSpan="2"/>
             <Border Name="imageB" BorderThickness="1" BorderBrush="Black" Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top" CornerRadius="4">
                 <Image Name="image" Stretch="Fill"/>
             </Border>
-            <Border Name="image1B" BorderThickness="1" BorderBrush="Black" Height="0" Width="0" HorizontalAlignment="Right" VerticalAlignment="Top" CornerRadius="4">
+            <Border Name="image1B" BorderThickness="1" BorderBrush="Black" Height="0" Width="0" HorizontalAlignment="Right" VerticalAlignment="Top" CornerRadius="4" Grid.Column="1">
                 <Image Name="image1" Stretch="Fill"/>
             </Border>
             <Border Name="image2B" BorderThickness="1" BorderBrush="Black" Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Bottom" CornerRadius="4">
                 <Image Name="image2" Stretch="Fill"/>
             </Border>
-            <Border Name="image3B" BorderThickness="1" BorderBrush="Black" Height="0" Width="0" HorizontalAlignment="Right" VerticalAlignment="Bottom" CornerRadius="4">
+            <Border Name="image3B" BorderThickness="1" BorderBrush="Black" Height="0" Width="0" HorizontalAlignment="Right" VerticalAlignment="Bottom" CornerRadius="4" Grid.Column="1">
                 <Grid Name="image3G">
                     <Image Name="image3" Stretch="Fill"/>
                     <Label Name="image3L" Content="" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="15.5" FontWeight="Bold" Visibility="Hidden"/>
@@ -46,8 +49,8 @@
                     Background="Transparent"
                     BorderBrush="Transparent"
                     ToolTip="Browse for images to upscale them."
-                    Height="80"/>
-            
+                    Height="94" Grid.ColumnSpan="2" AllowDrop="True"/>
+
             <Button x:Name="clearImagesButton"
                     Click="ClearImagesButton_Click"
                     Content="Clear"
@@ -55,7 +58,23 @@
                     Background="Transparent"
                     BorderBrush="Transparent"
                     ToolTip="Browse for images to upscale them."
-                    Height="20"/>
+                    Height="29" Grid.ColumnSpan="2"/>
+            <Grid ToolTip="When enabled, saves all the enhanced images into their own folder (very useful when you're enhancing several images)" Grid.ColumnSpan="2" Margin="10,124,10,-24">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="79*"/>
+                    <ColumnDefinition Width="24*"/>
+                    <ColumnDefinition Width="86*"/>
+                </Grid.ColumnDefinitions>
+
+                <CheckBox x:Name="outputFolderModeCheckBox"
+                    Click="OutputFolderModeCheckBox_Click"
+                    HorizontalAlignment="Left"
+                    Margin="22,4,0,4" ToolTip="All files will be placed inside a new folder within image's folder." Grid.ColumnSpan="3" Width="115">
+                    <TextBlock Text="Output as Folder" 
+                    VerticalAlignment="Center" Grid.ColumnSpan="3" Cursor="" ToolTip="All files will be placed inside a new folder within image's folder."/>
+
+                </CheckBox>
+            </Grid>
         </Grid>
 
         <StackPanel Grid.Column="1">
@@ -74,6 +93,9 @@
                           HorizontalAlignment="Stretch">
                     <ComboBoxItem Content="x2"/>
                     <ComboBoxItem Content="x4"/>
+                    <ComboBoxItem Content="x6"/>
+                    <ComboBoxItem Content="x8"/>
+                    <ComboBoxItem Content="x10"/>
                 </ComboBox>
             </Grid>
 
@@ -100,14 +122,14 @@
                     <ColumnDefinition Width="*"/>
                 </Grid.ColumnDefinitions>
 
-                <TextBlock Text="Output as Folder" 
-                           Margin="0,8,8,0"
-                           VerticalAlignment="Center"/>
-                <CheckBox Name="outputFolderModeCheckBox"
-                          Grid.Column="1"
+
+                <CheckBox x:Name="MaxSizeModeCheckBox"
                           Click="OutputFolderModeCheckBox_Click"
                           HorizontalAlignment="Left"
-                          Margin="0,8,0,0">
+                          Margin="0,8,0,0" IsChecked="True" ToolTip="Limits image's width/height to max 8K">
+                    <TextBlock Text="Limit size to 8K" 
+                           
+                           VerticalAlignment="Center" ToolTip="Limits image's width/height to max 8K pixels." Grid.ColumnSpan="2"/>
                 </CheckBox>
             </Grid>
 

--- a/NVIDIA Ansel AI Up Res/NVIDIA Ansel AI Up Res.csproj
+++ b/NVIDIA Ansel AI Up Res/NVIDIA Ansel AI Up Res.csproj
@@ -39,6 +39,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -48,6 +49,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
     <DebugSymbols>true</DebugSymbols>
@@ -58,6 +60,7 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>true</Prefer32Bit>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
     <OutputPath>bin\x64\Release\</OutputPath>
@@ -68,6 +71,7 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>true</Prefer32Bit>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>
     <ApplicationIcon>NVIDIA-GeForce-Experience.ico</ApplicationIcon>
@@ -75,6 +79,7 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Data" />
+    <Reference Include="System.Drawing" />
     <Reference Include="System.Management" />
     <Reference Include="System.Xml" />
     <Reference Include="Microsoft.CSharp" />
@@ -94,6 +99,7 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </ApplicationDefinition>
+    <Compile Include="TransparencySupport.cs" />
     <Page Include="MainWindow.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>

--- a/NVIDIA Ansel AI Up Res/TransparencySupport.cs
+++ b/NVIDIA Ansel AI Up Res/TransparencySupport.cs
@@ -1,0 +1,135 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Drawing.Drawing2D;
+using System.Drawing.Imaging;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+
+
+namespace NVIDIA_Ansel_AI_Up_Res
+{
+    public static class TransparencySupport
+    {
+        public static bool HasTransparency(Image img)
+        {
+            Bitmap bitmap = new Bitmap(img);
+            // Not an alpha-capable color format. Note that GDI+ indexed images are alpha-capable on the palette.
+            if (((ImageFlags)bitmap.Flags & ImageFlags.HasAlpha) == 0)
+                return false;
+            // Indexed format, and no alpha colours in the image's palette: immediate pass.
+            if ((bitmap.PixelFormat & PixelFormat.Indexed) != 0 && bitmap.Palette.Entries.All(c => c.A == 255))
+                return false;
+            // Get the byte data 'as 32-bit ARGB'. This offers a converted version of the image data without modifying the original image.
+            BitmapData data = bitmap.LockBits(new Rectangle(0, 0, bitmap.Width, bitmap.Height), ImageLockMode.ReadOnly, PixelFormat.Format32bppArgb);
+            Int32 len = bitmap.Height * data.Stride;
+            Byte[] bytes = new Byte[len];
+            Marshal.Copy(data.Scan0, bytes, 0, len);
+            bitmap.UnlockBits(data);
+            bitmap.Dispose();
+            // Check the alpha bytes in the data. Since the data is little-endian, the actual byte order is [BB GG RR AA]
+            for (Int32 i = 3; i < len; i += 4)
+                if (bytes[i] != 255)
+                    return true;
+            return false;
+        }
+
+        public static Bitmap UpsacleWithAlpha(string upscaled_path, string ip, double resolution, Func<string, bool, string, string> startUpscale)
+        {
+            Image source_img = Image.FromFile(ip);
+            // Convert all image's pixel to white - preserveing only alpha values
+            Bitmap alpha_img = ToAlphaChannel(new Bitmap(source_img));
+            string alpha_path = ip + "_alpha";
+            alpha_img.Save(alpha_path);
+            alpha_img.Dispose();
+            source_img.Dispose();
+
+            // Upscale the alpha channel image (using color - as the edges looks more clean that way)
+            string alphaUpscale_command = alpha_path + " " + resolution.ToString() + " 2";
+            string alphaUpscale_path = startUpscale(alphaUpscale_command, false, "alpha");
+            Bitmap fullImage = MergeAlphaChannel(upscaled_path, alphaUpscale_path);
+
+            // CleanUp
+            File.Delete(upscaled_path);
+            File.Delete(alpha_path);
+            File.Delete(alphaUpscale_path);
+
+            return fullImage;
+
+        }
+
+        private static Bitmap MergeAlphaChannel(string origin_path, string alphaChannel_path)
+        {
+            Image origin_img = Image.FromFile(origin_path),
+                alphaChannel_img = Image.FromFile(alphaChannel_path);
+            Bitmap origin_bit = new Bitmap(origin_img),
+                alphaChannel_bit = new Bitmap(alphaChannel_img);
+
+            Bitmap target = new Bitmap(origin_bit.Width, origin_bit.Height);
+            // Paints each pixel of the image.
+            // TODO: find faster method to combine "origin_img" & "alphaChannel_img"
+
+            for (int y = 0; y < origin_bit.Height; ++y)
+            {
+                for (int x = 0; x < origin_bit.Width; ++x)
+                {
+                    Color OriginPixel = origin_bit.GetPixel(x,y);
+                    Color AlphaPixel = alphaChannel_bit.GetPixel(x, y);
+                    byte alpha = AlphaPixel.R;
+                    Color newPixel = Color.FromArgb(alpha,
+                        PremultiplyAlpha(OriginPixel.R, alpha,y),
+                        PremultiplyAlpha(OriginPixel.G, alpha,y),
+                        PremultiplyAlpha(OriginPixel.B, alpha,y));
+                    // Creating new pixel of the final image, RGB data from original image,
+                    // while alpha data is from "alpha" image(black/white)
+
+                    target.SetPixel(x, y, newPixel);
+                }
+            }
+            origin_img.Dispose();
+            alphaChannel_img.Dispose();
+            origin_bit.Dispose();
+            alphaChannel_bit.Dispose();
+            return target;
+        }
+
+        private static Bitmap ToAlphaChannel(Bitmap Image)
+        {
+            Bitmap NewBitmap = (Bitmap)Image.Clone();
+            BitmapData data = NewBitmap.LockBits(
+                new Rectangle(0, 0, NewBitmap.Width, NewBitmap.Height),
+                ImageLockMode.ReadWrite,
+                NewBitmap.PixelFormat);
+            int Height = NewBitmap.Height;
+            int Width = NewBitmap.Width;
+
+            unsafe
+            {
+                for (int y = 0; y < Height; ++y)
+                {
+                    byte* row = (byte*)data.Scan0 + (y * data.Stride);
+                    int columnOffset = 0;
+                    for (int x = 0; x < Width; ++x)
+                    {
+                        row[columnOffset + 0] = (byte)255;
+                        row[columnOffset + 1] = (byte)255;
+                        row[columnOffset + 2] = (byte)255;
+                        columnOffset += 4;
+                    }
+                }
+            }
+            NewBitmap.UnlockBits(data);
+            return NewBitmap;
+        }
+
+        private static byte PremultiplyAlpha(byte source, byte alpha,int y)
+        {
+            if (y > 400)
+                return source;
+            return (byte)((float)(source) * (float)(alpha) / (float)(byte.MaxValue) + 0.5f);
+        }
+    }
+}


### PR DESCRIPTION
-Transparent images will get processed diffrently - in a way that will save the Transparecy_*****_
-More upscale factors.
-Added checkbox for limit scale factor if the images is larger then 8000px.
-Slight UI changes.

_*****_ It will preform 2 upscales and a full scan of each pixel of the upscaled image, the scan is can be really slow due to high res image size, if known a faster method to do so please share :) 